### PR TITLE
Updates to the container library necessary for Warden

### DIFF
--- a/IronFoundry.Container.Shared/ContainerProcess.cs
+++ b/IronFoundry.Container.Shared/ContainerProcess.cs
@@ -4,8 +4,15 @@ using IronFoundry.Container.Utilities;
 
 namespace IronFoundry.Container
 {
-    // BR: Move this to IronFoundry.Container.Shared
-    public class ContainerProcess
+    public interface IContainerProcess
+    {
+        int Id { get; }
+        void Kill();
+        int WaitForExit();
+        bool TryWaitForExit(int milliseconds, out int exitCode);
+    }
+
+    public class ContainerProcess : IContainerProcess
     {
         readonly IProcess process;
 

--- a/IronFoundry.Container.Shared/ExtensionMethods.cs
+++ b/IronFoundry.Container.Shared/ExtensionMethods.cs
@@ -271,3 +271,16 @@ namespace System.Threading
         }
     }
 }
+
+namespace System.Security.Principal
+{
+    public static class WindowsIdentityExtensionMethods
+    {
+        public static string GetUserName(this WindowsIdentity identity)
+        {
+            int splitIndex = identity.Name.IndexOf("\\");
+            string username = (splitIndex < 0) ? string.Empty : identity.Name.Substring(splitIndex + 1);
+            return username;
+        }
+    }
+}

--- a/IronFoundry.Container.Shared/ExtensionMethods.cs
+++ b/IronFoundry.Container.Shared/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -176,6 +177,18 @@ namespace System.Collections.Generic
             }
 
             return merged;
+        }
+
+        public static Dictionary<string, string> ToDictionary(this StringDictionary dictionary, IEqualityComparer<string> comparer)
+        {
+            var dict = new Dictionary<string, string>(comparer);
+
+            foreach (DictionaryEntry de in dictionary)
+            {
+                dict[(string) de.Key] = (string)de.Value;
+            }
+
+            return dict;
         }
     }
 }

--- a/IronFoundry.Container.Shared/ProcessRunner.cs
+++ b/IronFoundry.Container.Shared/ProcessRunner.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using IronFoundry.Container.Utilities;
+using IronFoundry.Container.Win32;
 
 namespace IronFoundry.Container
 {
@@ -64,13 +66,16 @@ namespace IronFoundry.Container
                 startInfo.Password = runSpec.Credentials.SecurePassword;
             }
 
+            Dictionary<string,string> environment = CreateDefaultProcessEnvironment(runSpec.Credentials);
             if (runSpec.Environment != null && runSpec.Environment.Count > 0)
             {
-                startInfo.EnvironmentVariables.Clear();
-                foreach (var variable in runSpec.Environment)
-                {
-                    startInfo.EnvironmentVariables[variable.Key] = variable.Value;
-                }
+                environment = runSpec.Environment;
+            }
+
+            startInfo.EnvironmentVariables.Clear();
+            foreach (var variable in environment)
+            {
+                startInfo.EnvironmentVariables[variable.Key] = variable.Value;
             }
 
             Process p = new Process
@@ -115,6 +120,30 @@ namespace IronFoundry.Container
 
         public void StopAll(bool kill)
         {
+        }
+
+        /// <summary>
+        /// Returns default environment for the process.
+        /// If credentials are specified then the default environment is the default for that user.
+        /// Otherwise the default is to inherit from this process.
+        /// </summary>
+        private Dictionary<string, string> CreateDefaultProcessEnvironment(NetworkCredential credential)
+        {
+            EnvironmentBlock envBlock = new EnvironmentBlock();
+
+            if (credential == null)
+            {
+                envBlock = EnvironmentBlock.Create(Environment.GetEnvironmentVariables());
+            }
+            else
+            {
+                using (var safeUserToken = Utils.LogonAndGetUserPrimaryToken(credential))
+                {
+                    envBlock = EnvironmentBlock.CreateForUser(safeUserToken.DangerousGetHandle());
+                }
+            }
+
+            return envBlock.ToDictionary();
         }
     }
 }

--- a/IronFoundry.Container.Shared/ProcessRunner.cs
+++ b/IronFoundry.Container.Shared/ProcessRunner.cs
@@ -66,11 +66,10 @@ namespace IronFoundry.Container
                 startInfo.Password = runSpec.Credentials.SecurePassword;
             }
 
-            Dictionary<string,string> environment = CreateDefaultProcessEnvironment(runSpec.Credentials);
-            if (runSpec.Environment != null && runSpec.Environment.Count > 0)
-            {
-                environment = runSpec.Environment;
-            }
+            bool runSpecSpecifiesEnvironment = runSpec.Environment != null && runSpec.Environment.Count > 0;
+            var environment = runSpecSpecifiesEnvironment
+                ? runSpec.Environment
+                : CreateDefaultProcessEnvironment(runSpec.Credentials);
 
             startInfo.EnvironmentVariables.Clear();
             foreach (var variable in environment)

--- a/IronFoundry.Container.Shared/Utilities/IProcess.cs
+++ b/IronFoundry.Container.Shared/Utilities/IProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace IronFoundry.Container.Utilities
@@ -10,6 +11,7 @@ namespace IronFoundry.Container.Utilities
         int ExitCode { get; }
         IntPtr Handle { get; }
         int Id { get; }
+        IReadOnlyDictionary<string, string> Environment { get; }
         
         long PrivateMemoryBytes { get; }
 

--- a/IronFoundry.Container.Shared/Utilities/ProcessHelper.cs
+++ b/IronFoundry.Container.Shared/Utilities/ProcessHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -59,6 +60,8 @@ namespace IronFoundry.Container.Utilities
 
                 this.process.OutputDataReceived += WrappedOutputDataReceived;
                 this.process.ErrorDataReceived += WrappedErrorDataReceived;
+
+                //this.Environment = this.process.StartInfo.EnvironmentVariables.
             }
 
             public int Id
@@ -75,6 +78,16 @@ namespace IronFoundry.Container.Utilities
             {
                 get { return process.Handle; }
             }
+
+            public IReadOnlyDictionary<string, string> Environment
+            {
+                get
+                {
+                    var dictionary = process.StartInfo.EnvironmentVariables.ToDictionary(StringComparer.OrdinalIgnoreCase);
+                    return new ReadOnlyDictionary<string, string>(dictionary);
+                }
+            }
+
 
             public long PrivateMemoryBytes
             {

--- a/IronFoundry.Container.Test/ConstrainedProcessRunnerTests.cs
+++ b/IronFoundry.Container.Test/ConstrainedProcessRunnerTests.cs
@@ -106,6 +106,29 @@ namespace IronFoundry.Container
 
                 Assert.Equal(expectedId, process.Id);
             }
+
+            [Fact]
+            public void ReturnsProcessWithEnvironment()
+            {
+                int expectedId = 123;
+                Client.CreateProcess(Arg.Any<CreateProcessParams>()).Returns(
+                new CreateProcessResult()
+                {
+                    id = expectedId
+                }
+                );
+
+                var spec = new ProcessRunSpec
+                {
+                    Environment = new Dictionary<string, string> {{"FOO", "BAR"}}
+                };
+
+                var process = Runner.Run(spec);
+
+                Assert.NotNull(process.Environment);
+                Assert.True(process.Environment.Count > 0);
+                Assert.Equal("BAR", process.Environment["FOO"]);
+            }
         }
 
         public class StopAll : ConstrainedProcessRunnerTests

--- a/IronFoundry.Container.Test/ConstrainedProcessTests.cs
+++ b/IronFoundry.Container.Test/ConstrainedProcessTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using IronFoundry.Container.Messages;
 using NSubstitute;
@@ -23,7 +24,7 @@ namespace IronFoundry.Container
             OutputCallback = delegate { };
             ErrorCallback = delegate { };
 
-            Process = new ConstrainedProcess(HostClient, ProcessKey, 100);
+            Process = new ConstrainedProcess(HostClient, ProcessKey, 100, new Dictionary<string, string>());
         }
 
         public class WaitForExit : ConstrainedProcessTests

--- a/IronFoundry.Container.Test/ContainerServiceTests.cs
+++ b/IronFoundry.Container.Test/ContainerServiceTests.cs
@@ -253,6 +253,18 @@ namespace IronFoundry.Container
                     Assert.Null(container);
                 }
             }
+
+            public class DestroyContainer : WithContainer
+            {
+                [Fact]
+                public void CanDestroyEnumeratedContainers()
+                {
+                    foreach (var container in Service.GetContainers())
+                    {
+                        Service.DestroyContainer(container.Handle);
+                    }
+                }
+            }
         }
     }
 }

--- a/IronFoundry.Container.Test/ProcessRunnerTests.cs
+++ b/IronFoundry.Container.Test/ProcessRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -229,6 +230,18 @@ namespace IronFoundry.Container
                         Assert.Contains(expected, output);
                     }
                 }
+            }
+
+            [Fact]
+            public void ReturnsProcessWithEnvironment()
+            {
+                var si = CreateRunSpec("cmd.exe", new[] { "/C" });
+
+                var p = Runner.Run(si);
+
+                Assert.NotNull(p.Environment);
+                Assert.True(p.Environment.Count > 0);
+                Assert.Equal(WindowsIdentity.GetCurrent().GetUserName(), p.Environment["USERNAME"]);
             }
 
         }

--- a/IronFoundry.Container.Test/ProcessRunnerTests.cs
+++ b/IronFoundry.Container.Test/ProcessRunnerTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using IronFoundry.Container.Utilities;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace IronFoundry.Container
 {
@@ -178,6 +180,57 @@ namespace IronFoundry.Container
 
                 var ex = Assert.Throws<System.ComponentModel.Win32Exception>(() => Runner.Run(si));
             }
+
+            [FactAdminRequired]
+            public async Task WhenCredentialsGiven_LoadsUserEnvironment()
+            {
+                LocalPrincipalManager manager = new LocalPrincipalManager(new DesktopPermissionManager());
+                var user = manager.CreateUser("Test_UserEnvironment");
+
+                try
+                {
+                    var si = CreateRunSpec("cmd.exe", new[] {"/C", "set"});
+                    si.Credentials = user;
+                    si.BufferedInputOutput = true;
+
+                    using (var p = Runner.Run(si))
+                    {
+                        WaitForGoodExit(p);
+
+                        var output = await p.StandardOutput.ReadToEndAsync();
+
+                        string expectedUserName = string.Format("USERNAME={0}", user.UserName);
+                        Assert.Contains(expectedUserName, output);
+                    }
+                }
+                finally
+                {
+                    manager.DeleteUser(user.UserName);
+                }
+            }
+
+            [Fact]
+            public void WhenCredentialsNotGiven_InheritsEnvironment()
+            {
+                var uniqueId = Guid.NewGuid().ToString("N");
+                Environment.SetEnvironmentVariable(uniqueId, "FOO");
+
+                using (var tempFile = CreateTempFile())
+                {
+                    var si = CreateRunSpec("cmd.exe", new[] { "/C", String.Format(@"set > {0}", tempFile.FullName) });
+
+                    using (var p = Runner.Run(si))
+                    {
+                        WaitForGoodExit(p);
+
+                        var output = tempFile.ReadAllText();
+
+                        string expected= string.Format("{0}={1}", uniqueId, "FOO");
+                        Assert.Contains(expected, output);
+                    }
+                }
+            }
+
         }
     }
 }

--- a/IronFoundry.Container.Test/Utilities/EnvironmentBlockTests.cs
+++ b/IronFoundry.Container.Test/Utilities/EnvironmentBlockTests.cs
@@ -1,4 +1,6 @@
-﻿namespace IronFoundry.Container.Utilities
+﻿using System.Security.Principal;
+
+namespace IronFoundry.Container.Utilities
 {
     using System.Collections;
     using System.Collections.Generic;
@@ -18,7 +20,7 @@
         [Fact]
         public void GeneratesDefaultEnvironment()
         {
-            var env = EnvironmentBlock.GenerateDefault();
+            var env = EnvironmentBlock.CreateSystemDefault();
             var dict = env.ToDictionary();
 
             Assert.True(dict.Count > 0);
@@ -32,12 +34,24 @@
         [Fact]
         public void MergeOverwritesOld()
         {
-            var env = EnvironmentBlock.GenerateDefault();
+            var env = EnvironmentBlock.CreateSystemDefault();
             var newEnv = EnvironmentBlock.Create(new Hashtable {{"COMPUTERNAME", "FOOBAR"}});
             var dict = env.Merge(newEnv).ToDictionary();
 
             Assert.Equal(env.ToDictionary().Count, dict.Count);
             Assert.Equal("FOOBAR", dict["COMPUTERNAME"]);
+        }
+
+        [Fact]
+        public void GeneratesEnvironmentForUseToken()
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            var userToken = identity.Token;
+            
+            var env = EnvironmentBlock.CreateForUser(userToken);
+            var dict = env.ToDictionary();
+
+            Assert.Equal(identity.GetUserName(), dict["USERNAME"]);
         }
     }
 }

--- a/IronFoundry.Container/ConstrainedProcess.cs
+++ b/IronFoundry.Container/ConstrainedProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using IronFoundry.Container.Messages;
 using IronFoundry.Container.Utilities;
@@ -16,11 +17,13 @@ namespace IronFoundry.Container
         public ConstrainedProcess(
             IContainerHostClient hostClient, 
             Guid key, 
-            int id)
+            int id,
+            Dictionary<string,string> environment)
         {
             this.hostClient = hostClient;
             this.key = key;
             this.id = id;
+            this.Environment = environment;
         }
 
         public int ExitCode
@@ -43,6 +46,8 @@ namespace IronFoundry.Container
         {
             get { return id; }
         }
+
+        public IReadOnlyDictionary<string, string> Environment { get; private set; }
 
         public long PrivateMemoryBytes
         {

--- a/IronFoundry.Container/ConstrainedProcessRunner.cs
+++ b/IronFoundry.Container/ConstrainedProcessRunner.cs
@@ -44,7 +44,7 @@ namespace IronFoundry.Container
         {
             Guid processKey = Guid.NewGuid();
             
-            var defaultEnvironmentBlock = EnvironmentBlock.GenerateDefault();
+            var defaultEnvironmentBlock = EnvironmentBlock.CreateSystemDefault();
 
             CreateProcessParams @params = new CreateProcessParams
             {

--- a/IronFoundry.Container/ConstrainedProcessRunner.cs
+++ b/IronFoundry.Container/ConstrainedProcessRunner.cs
@@ -45,13 +45,14 @@ namespace IronFoundry.Container
             Guid processKey = Guid.NewGuid();
             
             var defaultEnvironmentBlock = EnvironmentBlock.CreateSystemDefault();
+            var environment = defaultEnvironmentBlock.Merge(runSpec.Environment).ToDictionary();
 
             CreateProcessParams @params = new CreateProcessParams
             {
                 key = processKey,
                 executablePath = runSpec.ExecutablePath,
                 arguments = runSpec.Arguments,
-                environment = defaultEnvironmentBlock.Merge(runSpec.Environment).ToDictionary(),
+                environment = environment,
                 workingDirectory = runSpec.WorkingDirectory
             };
 
@@ -60,7 +61,7 @@ namespace IronFoundry.Container
             hostClient.SubscribeToProcessData(processKey, processDataCallback);
 
             var result = hostClient.CreateProcess(@params);
-            var process = new ConstrainedProcess(hostClient, processKey, result.id);
+            var process = new ConstrainedProcess(hostClient, processKey, result.id, environment);
 
             return process;
         }

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -43,7 +43,7 @@ namespace IronFoundry.Container
         void Stop(bool kill);
 
         int ReservePort(int requestedPort);
-        ContainerProcess Run(ProcessSpec spec, IProcessIO io);
+        IContainerProcess Run(ProcessSpec spec, IProcessIO io);
 
         void LimitMemory(ulong limitInBytes);
 
@@ -125,7 +125,7 @@ namespace IronFoundry.Container
             return reservedPort;
         }
 
-        public ContainerProcess Run(ProcessSpec spec, IProcessIO io)
+        public IContainerProcess Run(ProcessSpec spec, IProcessIO io)
         {
             ThrowIfNotActive();
 

--- a/IronFoundry.Container/ContainerService.cs
+++ b/IronFoundry.Container/ContainerService.cs
@@ -163,7 +163,7 @@ namespace IronFoundry.Container
 
         public IReadOnlyList<IContainer> GetContainers()
         {
-            return containers;
+            return containers.ToArray();
         }
     }
 }

--- a/IronFoundry.Warden/Tasks/ProcessCommand.cs
+++ b/IronFoundry.Warden/Tasks/ProcessCommand.cs
@@ -153,7 +153,7 @@ namespace IronFoundry.Warden.Tasks
             var rootedEnv = env.ToDictionary(kv => kv.Key, kv => container.ConvertToPathWithin(kv.Value));
 
             // Generate a new environment containing all the default values.
-            EnvironmentBlock defaultEnv = EnvironmentBlock.GenerateDefault();
+            EnvironmentBlock defaultEnv = EnvironmentBlock.CreateSystemDefault();
 
             // Merge the default envs with the machine and user provided variables
             var envHash = defaultEnv.Merge(rootedEnv).ToDictionary();


### PR DESCRIPTION
1. BUG FIX: ContainerService was returning its reference to the container list instead of a copy.
2. ProcessRunner now always sets environment explicitly on the ProcessStartInfo - if the defaults are used, there is no way to get the values.
3. The environment is exposed on IProcess - This is so we can create the env.log file.
4. ContainerProcess now has an interface.  Its current implementation isn't mockable which I need for some unit tests.