### PR TITLE
Container lib work

### DIFF
--- a/IronFoundry.Container.Host/App.config
+++ b/IronFoundry.Container.Host/App.config
@@ -1,5 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+  <configSections>
+    <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
+  </configSections>
+
+  <!-- <nlog throwExceptions="true" internalLogToConsole="true" internalLogLevel="Debug" -->
+  <nlog throwExceptions="true" async="false" xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <targets>
+      <target name="console" xsi:type="Console" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger:shortName=true}|${message}${onexception:|${exception:format=message,stacktrace:maxInnerExceptionLevel=10:innerFormat=message,stacktrace}}" />
+
+      <target name="file" xsi:type="File" layout="${longdate}|${level:uppercase=true}|${threadid}|${logger:shortName=true}|${message}${onexception:|${exception:format=message,stacktrace:maxInnerExceptionLevel=10:innerFormat=message,stacktrace}}" fileName="logs\hostlog.txt" archiveFileName="logs\hostlog-{#}.txt" archiveEvery="Day" archiveNumbering="Rolling" maxArchiveFiles="7" concurrentWrites="true" keepFileOpen="false" />
+    </targets>
+    <rules>
+      <!-- Use the following to log to the console -->
+      <!-- <logger name="*" minlevel="Trace" writeTo="console, file" /> -->
+      <logger name="*" minlevel="Trace" writeTo="file" />
+    </rules>
+  </nlog>
+  
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>

--- a/IronFoundry.Container.Shared/ContainerProcess.cs
+++ b/IronFoundry.Container.Shared/ContainerProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using IronFoundry.Container.Utilities;
 
@@ -7,6 +8,7 @@ namespace IronFoundry.Container
     public interface IContainerProcess
     {
         int Id { get; }
+        IReadOnlyDictionary<string, string> Environment { get; }
         void Kill();
         int WaitForExit();
         bool TryWaitForExit(int milliseconds, out int exitCode);
@@ -24,6 +26,10 @@ namespace IronFoundry.Container
         public int Id
         {
             get { return process.Id; }
+        }
+        public IReadOnlyDictionary<string, string> Environment
+        {
+            get { return process.Environment; }
         }
 
         public void Kill()

--- a/IronFoundry.Container.Shared/ExtensionMethods.cs
+++ b/IronFoundry.Container.Shared/ExtensionMethods.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace System
 {
@@ -81,7 +82,31 @@ public static class StringExtensionMethods
             return threwException;
         }
     }
+
+    public static class FuncExtensionMethods
+    {
+        /// <summary>
+        /// Retries the specified action until it returns true or up to the specified number
+        /// of retries.
+        /// </summary>
+        public static void RetryUpToNTimes(this Func<bool> action, int maxRetry, int sleepInMilli = 200)
+        {
+            for (int count = 0; count < maxRetry; count++)
+            {
+                if (action())
+                {
+                    break;
+                }
+                else
+                {
+                    Thread.Sleep(sleepInMilli);
+                }
+            }
+        }
+    }
 }
+
+
 
 public static class SecureStringExtensionMethod
 {

--- a/IronFoundry.Container.Shared/IContainerDirectory.cs
+++ b/IronFoundry.Container.Shared/IContainerDirectory.cs
@@ -82,7 +82,7 @@ namespace IronFoundry.Container
         {
             var basePath = CanonicalizePath(Path.Combine(containerPath, pathPrefix));
 
-            path = path.TrimStart('/');
+            path = path.TrimStart('/', '\\');
             var isRootPath = String.IsNullOrWhiteSpace(path);
 
             var mappedPath = CanonicalizePath(Path.Combine(basePath, path), ensureTrailingSlash: isRootPath);

--- a/IronFoundry.Container.Shared/IContainerDirectory.cs
+++ b/IronFoundry.Container.Shared/IContainerDirectory.cs
@@ -16,6 +16,7 @@ namespace IronFoundry.Container
         string MapBinPath(string containerPath);
         string MapPrivatePath(string containerPath);
         string MapUserPath(string containerPath);
+        void Destroy();
     }
 
     public class ContainerDirectory : IContainerDirectory
@@ -23,12 +24,14 @@ namespace IronFoundry.Container
         const string BinRelativePath = "bin";
         const string UserRelativePath = "user";
 
+        readonly FileSystemManager fileSystem;
         readonly string containerPath;
         readonly string containerBinPath;
         readonly string containerUserPath;
 
-        public ContainerDirectory(string containerPath)
+        public ContainerDirectory(FileSystemManager fileSystem, string containerPath)
         {
+            this.fileSystem = fileSystem;
             this.containerPath = containerPath;
 
             this.containerBinPath = CanonicalizePath(Path.Combine(containerPath, BinRelativePath), ensureTrailingSlash: true);
@@ -56,7 +59,18 @@ namespace IronFoundry.Container
             fileSystem.CreateDirectory(containerBinPath, GetContainerUserAccess(containerUser.UserName, FileAccess.Read));
             fileSystem.CreateDirectory(containerUserPath, GetContainerUserAccess(containerUser.UserName, FileAccess.ReadWrite));
 
-            return new ContainerDirectory(containerPath);
+            return new ContainerDirectory(fileSystem, containerPath);
+        }
+
+        public void Destroy()
+        {
+            try
+            {
+                fileSystem.DeleteDirectory(containerPath);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
         }
 
         public string MapBinPath(string path)

--- a/IronFoundry.Container.Shared/ProcessRunner.cs
+++ b/IronFoundry.Container.Shared/ProcessRunner.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using IronFoundry.Container.Utilities;
 using IronFoundry.Container.Win32;
+using NLog;
 
 namespace IronFoundry.Container
 {
@@ -40,6 +41,8 @@ namespace IronFoundry.Container
 
     public class ProcessRunner : IProcessRunner
     {
+        private readonly Logger log = LogManager.GetCurrentClassLogger();
+
         static readonly string[] EmptyArguments = new string[0];
 
         public void Dispose()
@@ -104,6 +107,11 @@ namespace IronFoundry.Container
                     };
                 }
             }
+
+            log.Trace("Starting Process - FileName: {0} Arguments: {1} WorkingDirectory: {2}", 
+                p.StartInfo.FileName,
+                p.StartInfo.Arguments,
+                p.StartInfo.WorkingDirectory);
 
             bool started = p.Start();
             Debug.Assert(started); // TODO: Should we throw an exception here? Fail fast?

--- a/IronFoundry.Container.Shared/Utilities/LocalPrincipalManager.cs
+++ b/IronFoundry.Container.Shared/Utilities/LocalPrincipalManager.cs
@@ -21,6 +21,8 @@ namespace IronFoundry.Container.Utilities
         private static extern int NetUserDel(string serverName, string userName);
 
         private const uint COM_EXCEPT_UNKNOWN_DIRECTORY_OBJECT = 0x80005004;
+        private const uint COM_EXCEPT_ERROR_NONE_MAPPED = 0x80070534;
+
         // TODO: Determine if adding the user to IIS_USRS is really a requirement for the
         // IISHost.  If it is, then pass an array of groups for the user instead of having this hardcoded.
         //private const string IIS_IUSRS_NAME = "IIS_IUSRS";
@@ -175,8 +177,13 @@ namespace IronFoundry.Container.Utilities
                 {
                     group = searcher.FindOne() as GroupPrincipal;
                 }
-                catch (COMException)
+                catch (COMException ex)
                 {
+                    // No mapping between account names and security IDs was done.
+                    if ((uint)ex.ErrorCode != COM_EXCEPT_ERROR_NONE_MAPPED)
+                    {
+                        throw;
+                    }
                 }
 
                 return group != null;

--- a/IronFoundry.Container.Shared/Utilities/LocalPrincipalManager.cs
+++ b/IronFoundry.Container.Shared/Utilities/LocalPrincipalManager.cs
@@ -35,8 +35,8 @@ namespace IronFoundry.Container.Utilities
             this.wardenUserGroups = userGroupNames ?? new String[0];
         }
 
-        public LocalPrincipalManager(string userGroupName)
-            : this(new DesktopPermissionManager(), userGroupName)
+        public LocalPrincipalManager(params string [] userGroupNames)
+            : this(new DesktopPermissionManager(), userGroupNames)
         {
         }
 

--- a/IronFoundry.Container.Test/ContainerDirectoryTests.cs
+++ b/IronFoundry.Container.Test/ContainerDirectoryTests.cs
@@ -228,8 +228,11 @@ namespace IronFoundry.Container
 
         public class MapUserPath : ContainerDirectoryTests
         {
+            [InlineData("", @"C:\Containers\handle\user\")]
+            [InlineData("\\", @"C:\Containers\handle\user\")]
             [InlineData("/", @"C:\Containers\handle\user\")]
             [InlineData("/path/to/app", @"C:\Containers\handle\user\path\to\app")]
+            [InlineData(@"\path\to\app", @"C:\Containers\handle\user\path\to\app")]
             [Theory]
             public void MapsRootedPathRelativeToContainerUserPath(string containerPath, string expectedMappedPath)
             {

--- a/IronFoundry.Container.Test/ContainerDirectoryTests.cs
+++ b/IronFoundry.Container.Test/ContainerDirectoryTests.cs
@@ -25,7 +25,6 @@ namespace IronFoundry.Container
 
         public class Create : ContainerDirectoryTests
         {
-            FileSystemManager FileSystem { get; set; }
             IContainerUser ContainerUser { get; set; }
 
             public Create()

--- a/IronFoundry.Container.Test/ContainerDirectoryTests.cs
+++ b/IronFoundry.Container.Test/ContainerDirectoryTests.cs
@@ -15,13 +15,15 @@ namespace IronFoundry.Container
     public class ContainerDirectoryTests
     {
         ContainerDirectory Directory { get; set; }
+        FileSystemManager FileSystem { get; set; }
 
         public ContainerDirectoryTests()
         {
-            Directory = new ContainerDirectory(@"C:\Containers\handle");
+            FileSystem = Substitute.For<FileSystemManager>();
+            Directory = new ContainerDirectory(FileSystem, @"C:\Containers\handle");
         }
 
-        public class Create
+        public class Create : ContainerDirectoryTests
         {
             FileSystemManager FileSystem { get; set; }
             IContainerUser ContainerUser { get; set; }
@@ -117,6 +119,25 @@ namespace IronFoundry.Container
                         Assert.Equal("username", x.UserName);
                         Assert.Equal(FileAccess.ReadWrite, x.Access);
                     });
+            }
+        }
+
+        public class Destroy : ContainerDirectoryTests
+        {
+            private IContainerUser ContainerUser { get; set; }
+
+            public Destroy()
+            {
+                ContainerUser = Substitute.For<IContainerUser>();
+                ContainerUser.UserName.Returns("username");
+            }
+
+            [Fact]
+            public void DeletesContainerDirectory()
+            {
+                ContainerDirectory directory = ContainerDirectory.Create(FileSystem, @"c:\Containers", "handle", ContainerUser);
+                directory.Destroy();
+                FileSystem.Received(1).DeleteDirectory(@"c:\Containers\handle");
             }
         }
 

--- a/IronFoundry.Container.Test/ContainerHostServiceTests.cs
+++ b/IronFoundry.Container.Test/ContainerHostServiceTests.cs
@@ -46,6 +46,8 @@ namespace IronFoundry.Container
             DependencyHelper.ContainerHostExePath.Returns(@"C:\Path\To\IronFoundry.Container.Host.exe");
             DependencyHelper.GetContainerHostDependencies().Returns(new [] { @"C:\Path\To\IronFoundry.Container.Shared.dll" });
 
+            FileSystem.FileExists(DependencyHelper.ContainerHostExeConfigPath).Returns(true);
+
             Service = new ContainerHostService(FileSystem, ProcessRunner, DependencyHelper);
         }
 
@@ -58,6 +60,7 @@ namespace IronFoundry.Container
                 client = Service.StartContainerHost(ContainerId, Directory, JobObject, null);
                 
                 FileSystem.Received(1).CopyFile(@"C:\Path\To\IronFoundry.Container.Host.exe", @"C:\Containers\handle\bin\IronFoundry.Container.Host.exe");
+                FileSystem.Received(1).CopyFile(@"C:\Path\To\IronFoundry.Container.Host.exe.config", @"C:\Containers\handle\bin\IronFoundry.Container.Host.exe.config");
                 FileSystem.Received(1).CopyFile(@"C:\Path\To\IronFoundry.Container.Shared.dll", @"C:\Containers\handle\bin\IronFoundry.Container.Shared.dll");
             }
             finally

--- a/IronFoundry.Container.Test/ContainerServiceTests.cs
+++ b/IronFoundry.Container.Test/ContainerServiceTests.cs
@@ -29,6 +29,7 @@ namespace IronFoundry.Container
         IUserManager UserManager { get; set; }
         ILocalTcpPortManager TcpPortManager { get; set; }
         ContainerService Service { get; set; }
+        public string Id { get; set; }
 
         public ContainerServiceTests()
         {
@@ -39,8 +40,10 @@ namespace IronFoundry.Container
 
             FileSystem = Substitute.For<FileSystemManager>();
 
+            Id = "DEADBEEF";
+
             HandleHelper = Substitute.For<ContainerHandleHelper>();
-            HandleHelper.GenerateId(null).ReturnsForAnyArgs("DEADBEEF");
+            HandleHelper.GenerateId(null).ReturnsForAnyArgs(Id);
 
             ProcessRunner = Substitute.For<IProcessRunner>();
             TcpPortManager = Substitute.For<ILocalTcpPortManager>();
@@ -196,6 +199,9 @@ namespace IronFoundry.Container
                 // Created and deleted the user
                 UserManager.Received(1).CreateUser(Arg.Any<string>());
                 UserManager.Received(1).DeleteUser(Arg.Any<string>());
+                
+                // Deleted the container directory
+                FileSystem.Received(1).DeleteDirectory(ContainerBasePath + "\\" + Id);
             }
         }
 

--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -162,7 +162,7 @@ namespace IronFoundry.Container
                     Assert.Equal(ExpectedRunSpec.ExecutablePath, actual.ExecutablePath);
                     Assert.Equal(ExpectedRunSpec.Arguments, actual.Arguments);
                     Assert.Superset(
-                        new HashSet<string>(ExpectedRunSpec.Environment.Keys), 
+                        new HashSet<string>(ExpectedRunSpec.Environment.Keys),
                         new HashSet<string>(actual.Environment.Keys));
                     Assert.Equal(ExpectedRunSpec.WorkingDirectory, actual.WorkingDirectory);
                 }
@@ -226,6 +226,20 @@ namespace IronFoundry.Container
                     var actualSpec = ProcessRunner.Captured(x => x.Run(null)).Arg<ProcessRunSpec>();
 
                     Assert.Equal(Spec.Environment, actualSpec.Environment);
+                }
+
+                [Fact]
+                public void WhenPathMappingDisabled_DoesntMapWorkingDir()
+                {
+                    Spec.WorkingDirectory = @"c:\workingdir";
+                    Spec.DisablePathMapping = true;
+
+                    var io = Substitute.For<IProcessIO>();
+                    var process = Container.Run(Spec, io);
+
+                    var actual = ProcessRunner.Captured(x => x.Run(null)).Arg<ProcessRunSpec>();
+
+                    Assert.Equal(@"c:\workingdir", actual.WorkingDirectory);
                 }
             }
 

--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -546,6 +546,15 @@ namespace IronFoundry.Container
         public class Stop : ContainerTests
         {
             [Fact]
+            public void DisposesProcessRunners()
+            {
+                Container.Stop(false);
+
+                ProcessRunner.Received(1).Dispose();
+                ConstrainedProcessRunner.Received(1).Dispose();
+            }
+
+            [Fact]
             public void WhenContainerDestroyed_Throws()
             {
                 Container.Destroy();

--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -227,20 +227,6 @@ namespace IronFoundry.Container
 
                     Assert.Equal(Spec.Environment, actualSpec.Environment);
                 }
-
-                [Fact]
-                public void WhenPathMappingDisabled_DoesntMapWorkingDir()
-                {
-                    Spec.WorkingDirectory = @"c:\workingdir";
-                    Spec.DisablePathMapping = true;
-
-                    var io = Substitute.For<IProcessIO>();
-                    var process = Container.Run(Spec, io);
-
-                    var actual = ProcessRunner.Captured(x => x.Run(null)).Arg<ProcessRunSpec>();
-
-                    Assert.Equal(@"c:\workingdir", actual.WorkingDirectory);
-                }
             }
 
             public class WhenNotPrivileged : Run

--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -287,6 +287,22 @@ namespace IronFoundry.Container
                 }
 
                 [Fact]
+                public void ProcessIoCanBeNull()
+                {
+                    var io = new TestProcessIO();
+                    io.Output = null;
+                    io.Error = null;
+
+                    Container.Run(Spec, io);
+
+                    var proc = ConstrainedProcessRunner.Captured(x => x.Run(null)).Arg<ProcessRunSpec>();
+
+                    Assert.Equal(null, proc.OutputCallback);
+                    Assert.Equal(null, proc.ErrorCallback);
+                }
+
+
+                [Fact]
                 public void WhenPathMappingIsDisabled_DoesNotMapExecutablePath()
                 {
                     var io = Substitute.For<IProcessIO>();

--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -354,6 +354,15 @@ namespace IronFoundry.Container
                 ConstrainedProcessRunner.Received(1).Dispose();
             }
 
+
+            [Fact]
+            public void DeletesContainerDirectory()
+            {
+                Container.Destroy();
+
+                this.Directory.Received(1).Destroy();
+            }
+
             [Fact]
             public void WhenContainerStopped_Runs()
             {

--- a/IronFoundry.Container.Test/IronFoundry.Container.Test.csproj
+++ b/IronFoundry.Container.Test/IronFoundry.Container.Test.csproj
@@ -91,6 +91,7 @@
     <Compile Include="TestSupport\TestProcessIO.cs" />
     <Compile Include="Utilities\EffectiveAccessComputerTests.cs" />
     <Compile Include="Utilities\EnvironmentBlockTests.cs" />
+    <Compile Include="Utilities\ExtensionMethodsTests.cs" />
     <Compile Include="Utilities\FileSystemEffectiveAccessComputerTests.cs" />
     <Compile Include="Utilities\FileSystemManagerTests.cs" />
     <Compile Include="Handlers\CreateProcessHandlerTests.cs" />

--- a/IronFoundry.Container.Test/ProcessRunnerTests.cs
+++ b/IronFoundry.Container.Test/ProcessRunnerTests.cs
@@ -186,7 +186,13 @@ namespace IronFoundry.Container
             public async Task WhenCredentialsGiven_LoadsUserEnvironment()
             {
                 LocalPrincipalManager manager = new LocalPrincipalManager(new DesktopPermissionManager());
-                var user = manager.CreateUser("Test_UserEnvironment");
+                
+                string userName = "Test_UserEnvironment";
+                if (manager.FindUser(userName) != null)
+                {
+                    manager.DeleteUser(userName);
+                }
+                var user = manager.CreateUser(userName);
 
                 try
                 {
@@ -206,7 +212,7 @@ namespace IronFoundry.Container
                 }
                 finally
                 {
-                    manager.DeleteUser(user.UserName);
+                    manager.DeleteUser(userName);
                 }
             }
 

--- a/IronFoundry.Container.Test/Utilities/ExtensionMethodsTests.cs
+++ b/IronFoundry.Container.Test/Utilities/ExtensionMethodsTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IronFoundry.Container.Utilities
+{
+    public class ExtensionMethodsTests
+    {
+        public class FuncExtensionMethods : ExtensionMethodsTests
+        {
+            public class RetryUpToNTimes : FuncExtensionMethods
+            {
+                [Fact]
+                public void WhenActionReturnsFalseContinuously_RetriesUpToN()
+                {
+                    int count = 0;
+
+                    Func<bool> failingAction = () =>
+                    {
+                        count++;
+                        return false;
+                    };
+
+                    failingAction.RetryUpToNTimes(10, 0);
+
+                    Assert.Equal(10, count);
+                }
+
+                [Fact]
+                public void WhenActionReturnsTrue_StopsRetrying()
+                {
+                    int count = 0;
+
+                    Func<bool> trueAfterThree = () =>
+                    {
+                        count++;
+                        return count == 3;
+                    };
+
+                    trueAfterThree.RetryUpToNTimes(10, 0);
+
+                    Assert.Equal(3, count);
+                }
+            }
+        }
+    }
+}

--- a/IronFoundry.Container/ConstrainedProcessRunner.cs
+++ b/IronFoundry.Container/ConstrainedProcessRunner.cs
@@ -8,7 +8,7 @@ namespace IronFoundry.Container
     {
         public const int DefaultStopTimeout = 10000;
 
-        readonly IContainerHostClient hostClient;
+        IContainerHostClient hostClient;
 
         public ConstrainedProcessRunner(IContainerHostClient hostClient)
         {
@@ -37,7 +37,10 @@ namespace IronFoundry.Container
         public void Dispose()
         {
             if (hostClient != null)
+            {
                 hostClient.Dispose();
+                hostClient = null;
+            }
         }
 
         public IProcess Run(ProcessRunSpec runSpec)
@@ -68,8 +71,11 @@ namespace IronFoundry.Container
 
         public void StopAll(bool kill)
         {
-            var timeout = kill ? 0 : DefaultStopTimeout;
-            hostClient.StopAllProcesses(timeout);
+            if (hostClient != null)
+            {
+                var timeout = kill ? 0 : DefaultStopTimeout;
+                hostClient.StopAllProcesses(timeout);
+            }
         }
     }
 }

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -63,13 +63,13 @@ namespace IronFoundry.Container
         readonly IContainerDirectory directory;
         readonly ILocalTcpPortManager tcpPortManager;
         readonly JobObject jobObject;
-        readonly IProcessRunner processRunner;
-        readonly IProcessRunner constrainedProcessRunner;
         readonly ProcessHelper processHelper;
         readonly IContainerPropertyService propertyService;
         readonly Dictionary<string, string> defaultEnvironment;
         readonly List<int> reservedPorts = new List<int>();
 
+        IProcessRunner processRunner;
+        IProcessRunner constrainedProcessRunner;
         ContainerState currentState;
 
         public Container(
@@ -191,12 +191,6 @@ namespace IronFoundry.Container
             if (user != null)
                 user.Delete();
 
-            if (constrainedProcessRunner != null)
-                constrainedProcessRunner.Dispose();
-
-            if (processRunner != null)
-                processRunner.Dispose();
-
             if (directory != null)
                 directory.Destroy();
             
@@ -261,10 +255,18 @@ namespace IronFoundry.Container
             ThrowIfDestroyed();
 
             if (constrainedProcessRunner != null)
+            {
                 constrainedProcessRunner.StopAll(kill);
+                constrainedProcessRunner.Dispose();
+                constrainedProcessRunner = null;
+            }
 
             if (processRunner != null)
+            {
                 processRunner.StopAll(kill);
+                processRunner.Dispose();
+                processRunner = null;
+            }
 
             this.currentState = ContainerState.Stopped;
         }

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -189,6 +189,9 @@ namespace IronFoundry.Container
             if (processRunner != null)
                 processRunner.Dispose();
 
+            if (directory != null)
+                directory.Destroy();
+            
             this.currentState = ContainerState.Destroyed;
         }
 

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -146,14 +146,22 @@ namespace IronFoundry.Container
             var specEnvironment = spec.Environment ?? new Dictionary<string, string>();
             var processEnvironment = this.defaultEnvironment.Merge(specEnvironment);
 
+            Action<string> stdOut = io == null || io.StandardOutput == null 
+                ? (Action<string>)null 
+                : data => io.StandardOutput.Write(data);
+
+            Action<string> stdErr = io == null || io.StandardError == null 
+                ? (Action<string>)null 
+                : data => io.StandardError.Write(data);
+
             var runSpec = new ProcessRunSpec
             {
                 ExecutablePath = executablePath,
                 Arguments = spec.Arguments,
                 Environment = processEnvironment,
                 WorkingDirectory = workingDirectory,
-                OutputCallback = data => io.StandardOutput.Write(data),
-                ErrorCallback = data => io.StandardError.Write(data),
+                OutputCallback = stdOut,
+                ErrorCallback = stdErr,
             };
 
             var process = runner.Run(runSpec);

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -30,6 +30,7 @@ namespace IronFoundry.Container
         string Id { get; }
         string Handle { get; }
         //ContainerState State { get; }
+
         IContainerDirectory Directory { get; }
 
         //void BindMounts(IEnumerable<BindMount> mounts);
@@ -137,6 +138,11 @@ namespace IronFoundry.Container
                 directory.MapUserPath(spec.ExecutablePath) :
                 spec.ExecutablePath;
 
+            var workingDirectory = spec.WorkingDirectory ?? DefaultWorkingDirectory;
+            workingDirectory = !spec.DisablePathMapping
+                ? directory.MapUserPath(workingDirectory)
+                : workingDirectory;
+
             var specEnvironment = spec.Environment ?? new Dictionary<string, string>();
             var processEnvironment = this.defaultEnvironment.Merge(specEnvironment);
 
@@ -145,7 +151,7 @@ namespace IronFoundry.Container
                 ExecutablePath = executablePath,
                 Arguments = spec.Arguments,
                 Environment = processEnvironment,
-                WorkingDirectory = directory.MapUserPath(spec.WorkingDirectory ?? DefaultWorkingDirectory),
+                WorkingDirectory = workingDirectory,
                 OutputCallback = data => io.StandardOutput.Write(data),
                 ErrorCallback = data => io.StandardError.Write(data),
             };

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -30,7 +30,6 @@ namespace IronFoundry.Container
         string Id { get; }
         string Handle { get; }
         //ContainerState State { get; }
-
         IContainerDirectory Directory { get; }
 
         //void BindMounts(IEnumerable<BindMount> mounts);
@@ -138,11 +137,6 @@ namespace IronFoundry.Container
                 directory.MapUserPath(spec.ExecutablePath) :
                 spec.ExecutablePath;
 
-            var workingDirectory = spec.WorkingDirectory ?? DefaultWorkingDirectory;
-            workingDirectory = !spec.DisablePathMapping
-                ? directory.MapUserPath(workingDirectory)
-                : workingDirectory;
-
             var specEnvironment = spec.Environment ?? new Dictionary<string, string>();
             var processEnvironment = this.defaultEnvironment.Merge(specEnvironment);
 
@@ -159,7 +153,7 @@ namespace IronFoundry.Container
                 ExecutablePath = executablePath,
                 Arguments = spec.Arguments,
                 Environment = processEnvironment,
-                WorkingDirectory = workingDirectory,
+                WorkingDirectory = directory.MapUserPath(spec.WorkingDirectory ?? DefaultWorkingDirectory),
                 OutputCallback = stdOut,
                 ErrorCallback = stdErr,
             };

--- a/IronFoundry.Container/ContainerHostDependencyHelper.cs
+++ b/IronFoundry.Container/ContainerHostDependencyHelper.cs
@@ -27,6 +27,16 @@ namespace IronFoundry.Container
             get { return containerHostAssembly.Location; }
         }
 
+        public string ContainerHostExeConfig
+        {
+            get { return ContainerHostExe + ".config"; }
+        }
+
+        public string ContainerHostExeConfigPath
+        {
+            get { return ContainerHostExePath + ".config"; }
+        }
+
         static Assembly GetContainerHostAssembly()
         {
             return Assembly.ReflectionOnlyLoad(ContainerHostAssemblyName);

--- a/IronFoundry.Container/ContainerHostService.cs
+++ b/IronFoundry.Container/ContainerHostService.cs
@@ -39,11 +39,22 @@ namespace IronFoundry.Container
         {
         }
 
-        void CopyHostToContainer(IContainerDirectory directory)
+        private void CopyHostToContainer(IContainerDirectory directory)
         {
             fileSystem.CopyFile(
-                dependencyHelper.ContainerHostExePath, 
+                dependencyHelper.ContainerHostExePath,
                 directory.MapBinPath(dependencyHelper.ContainerHostExe));
+
+            // This check is here for the acceptance tests.
+            // They get ContainerHost.exe by referencing the project.  However, msbuild does
+            // not copy .config files of referenced assemblies.  Thus when running the acceptance
+            // tests, the ContainerHost.exe used does not have an app.config.
+            if (fileSystem.FileExists(dependencyHelper.ContainerHostExeConfigPath))
+            {
+                fileSystem.CopyFile(
+                    dependencyHelper.ContainerHostExeConfigPath,
+                    directory.MapBinPath(dependencyHelper.ContainerHostExeConfig));
+            }
 
             foreach (var dependencyFilePath in dependencyHelper.GetContainerHostDependencies())
             {

--- a/IronFoundry.Container/ContainerService.cs
+++ b/IronFoundry.Container/ContainerService.cs
@@ -24,6 +24,7 @@ namespace IronFoundry.Container
 
     public class ContainerService : IContainerService
     {
+        const string IIS_USRS_GROUP = "IIS_IUSRS";
         const string PropertiesFileName = "properties.json";
 
         readonly string containerBasePath;
@@ -60,7 +61,7 @@ namespace IronFoundry.Container
         public ContainerService(string containerBasePath, string userGroupName)
             : this(
                 new ContainerHandleHelper(),
-                new LocalPrincipalManager(userGroupName),
+                new LocalPrincipalManager(userGroupName, IIS_USRS_GROUP),
                 new FileSystemManager(),
                 new LocalFilePropertyService(new FileSystemManager(), PropertiesFileName),
                 new LocalTcpPortManager(),

--- a/IronFoundry.Container/ContainerService.cs
+++ b/IronFoundry.Container/ContainerService.cs
@@ -91,8 +91,7 @@ namespace IronFoundry.Container
                 undoStack.Push(() => user.Delete());
 
                 var directory = ContainerDirectory.Create(fileSystem, containerBasePath, id, user);
-                // BR: This is wrong. This should destroy the ContainerDirectory object, not delete the entire base path!
-                undoStack.Push(() => fileSystem.DeleteDirectory(containerBasePath));
+                undoStack.Push(() => fileSystem.DeleteDirectory(directory.RootPath));
 
                 var jobObject = new JobObject(handle);
                 undoStack.Push(() => jobObject.Dispose());

--- a/IronFoundry.Container/IContainerPropertyService.cs
+++ b/IronFoundry.Container/IContainerPropertyService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace IronFoundry.Container.Internal
+namespace IronFoundry.Container
 {
     public interface IContainerPropertyService
     {

--- a/IronFoundry.Container/IronFoundry.Container.csproj
+++ b/IronFoundry.Container/IronFoundry.Container.csproj
@@ -65,7 +65,7 @@
     <Compile Include="ContainerUser.cs" />
     <Compile Include="ContainerHostService.cs" />
     <Compile Include="Internal\Clock.cs" />
-    <Compile Include="Internal\IContainerPropertyService.cs" />
+    <Compile Include="IContainerPropertyService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Internal\LocalFilePropertyService.cs" />
   </ItemGroup>


### PR DESCRIPTION
There are a variety of fixes here for the warden refactoring work:
1. I've added logging for the containerhost.exe (needed it to debug failures in running tasks).  They will go to the users/logs folder right now.
2. Added the container user to IIS_IUSRS - We will want to change this later by changing the tempDirectory instead. I've added a card for that.
3. Follow the same path mapping logic for the working directory as we do for the exePath.
4. MISC bug fixes
