### PR TITLE
Fixes IronFoundry/if_release#13 - iishost.exe was failing to create log

### DIFF
--- a/IronFoundry.Container.Shared/IContainerDirectory.cs
+++ b/IronFoundry.Container.Shared/IContainerDirectory.cs
@@ -23,6 +23,7 @@ namespace IronFoundry.Container
     {
         const string BinRelativePath = "bin";
         const string UserRelativePath = "user";
+        const string PrivateRelativePath = "private";
 
         readonly FileSystemManager fileSystem;
         readonly string containerPath;
@@ -52,10 +53,12 @@ namespace IronFoundry.Container
         {
             // TODO: Sanitize the container handle for use in the filesystem
             var containerPath = Path.Combine(containerBasePath, containerHandle);
+            var containerPrivatePath = Path.Combine(containerPath, PrivateRelativePath);
             var containerUserPath = Path.Combine(containerPath, UserRelativePath);
             var containerBinPath = Path.Combine(containerPath, BinRelativePath);
 
             fileSystem.CreateDirectory(containerPath, GetContainerUserAccess(containerUser.UserName, FileAccess.Read));
+            fileSystem.CreateDirectory(containerPrivatePath, GetContainerDefaultAccess());
             fileSystem.CreateDirectory(containerBinPath, GetContainerUserAccess(containerUser.UserName, FileAccess.Read));
             fileSystem.CreateDirectory(containerUserPath, GetContainerUserAccess(containerUser.UserName, FileAccess.ReadWrite));
 
@@ -95,7 +98,7 @@ namespace IronFoundry.Container
 
         public string MapPrivatePath(string path)
         {
-            return MapContainerPath("", path);
+            return MapContainerPath(PrivateRelativePath, path);
         }
 
         public string MapUserPath(string path)

--- a/IronFoundry.Container.Shared/IContainerDirectory.cs
+++ b/IronFoundry.Container.Shared/IContainerDirectory.cs
@@ -55,7 +55,7 @@ namespace IronFoundry.Container
             var containerUserPath = Path.Combine(containerPath, UserRelativePath);
             var containerBinPath = Path.Combine(containerPath, BinRelativePath);
 
-            fileSystem.CreateDirectory(containerPath, GetContainerDefaultAccess());
+            fileSystem.CreateDirectory(containerPath, GetContainerUserAccess(containerUser.UserName, FileAccess.Read));
             fileSystem.CreateDirectory(containerBinPath, GetContainerUserAccess(containerUser.UserName, FileAccess.Read));
             fileSystem.CreateDirectory(containerUserPath, GetContainerUserAccess(containerUser.UserName, FileAccess.ReadWrite));
 

--- a/IronFoundry.Container.Test/ContainerDirectoryTests.cs
+++ b/IronFoundry.Container.Test/ContainerDirectoryTests.cs
@@ -36,7 +36,7 @@ namespace IronFoundry.Container
             }
 
             [Fact]
-            public void CreatesContainerDirectoryWithAdminPermissions()
+            public void CreatesContainerDirectoryWithUserReadOnlyPermissions()
             {
                 IEnumerable<UserAccess> userAccess = null;
                 FileSystem.CreateDirectory(
@@ -48,14 +48,21 @@ namespace IronFoundry.Container
 
                 Assert.NotNull(directory);
                 Assert.Collection(userAccess,
-                    x => {
+                    x =>
+                    {
                         Assert.Equal(@"BUILTIN\Administrators", x.UserName);
                         Assert.Equal(FileAccess.ReadWrite, x.Access);
                     },
-                    x => {
+                    x =>
+                    {
                         Assert.NotEmpty(x.UserName);
                         Assert.Equal(WindowsIdentity.GetCurrent().Name, x.UserName);
                         Assert.Equal(FileAccess.ReadWrite, x.Access);
+                    },
+                    x =>
+                    {
+                        Assert.Equal("username", x.UserName);
+                        Assert.Equal(FileAccess.Read, x.Access);
                     });
             }
 

--- a/IronFoundry.Container.Test/ContainerDirectoryTests.cs
+++ b/IronFoundry.Container.Test/ContainerDirectoryTests.cs
@@ -192,8 +192,8 @@ namespace IronFoundry.Container
 
         public class MapPrivatePath : ContainerDirectoryTests
         {
-            [InlineData("/", @"C:\Containers\handle\")]
-            [InlineData("/path/to/data", @"C:\Containers\handle\path\to\data")]
+            [InlineData("/", @"C:\Containers\handle\private\")]
+            [InlineData("/path/to/data", @"C:\Containers\handle\private\path\to\data")]
             [Theory]
             public void MapsRootedPathRelativeToContainerRootPath(string containerPath, string expectedMappedPath)
             {
@@ -207,7 +207,7 @@ namespace IronFoundry.Container
             {
                 var mappedPath = Directory.MapPrivatePath("/path/to/data");
 
-                Assert.Equal(@"C:\Containers\handle\path\to\data", mappedPath);
+                Assert.Equal(@"C:\Containers\handle\private\path\to\data", mappedPath);
             }
 
             [Fact]
@@ -215,7 +215,7 @@ namespace IronFoundry.Container
             {
                 var mappedPath = Directory.MapPrivatePath("/path/to/../../data");
 
-                Assert.Equal(@"C:\Containers\handle\data", mappedPath);
+                Assert.Equal(@"C:\Containers\handle\private\data", mappedPath);
             }
 
             [InlineData("/data/../..")]


### PR DESCRIPTION
files because it apparently requires read permissions to all directories
that make up the log path.  Before the fix, the container user did not get
any priviledges to the container base directory.  After the fix, it has
read/execute access. This shouldn't really be a problem, after all it
already had read/execute access to all the subdirectories anyway.