### PR TITLE
Add CurrentMemoryLimit to IContainer

### DIFF
--- a/IronFoundry.Container.Test/ContainerTests.cs
+++ b/IronFoundry.Container.Test/ContainerTests.cs
@@ -505,6 +505,14 @@ namespace IronFoundry.Container
 
                 Assert.Throws<InvalidOperationException>(action);
             }
+
+            [Fact]
+            public void ReturnsMemoryLimit()
+            {
+                ulong limitInBytes = 2048;
+                JobObject.GetJobMemoryLimit().Returns(limitInBytes);
+                Assert.Equal(limitInBytes, Container.CurrentMemoryLimit());
+            }
         }
 
         public class RemoveProperty : ContainerTests

--- a/IronFoundry.Container/Container.cs
+++ b/IronFoundry.Container/Container.cs
@@ -46,6 +46,7 @@ namespace IronFoundry.Container
         IContainerProcess Run(ProcessSpec spec, IProcessIO io);
 
         void LimitMemory(ulong limitInBytes);
+        ulong CurrentMemoryLimit();
 
         void SetProperty(string name, string value);
         string GetProperty(string name);
@@ -168,6 +169,11 @@ namespace IronFoundry.Container
             ThrowIfNotActive();
 
             this.jobObject.SetJobMemoryLimit(limitInBytes);
+        }
+
+        public ulong CurrentMemoryLimit()
+        {
+            return jobObject.GetJobMemoryLimit();
         }
 
         public void Destroy()

--- a/IronFoundry.Warden/Containers/ContainerStub.cs
+++ b/IronFoundry.Warden/Containers/ContainerStub.cs
@@ -301,6 +301,11 @@ namespace IronFoundry.Warden.Containers
             jobObjectLimits.LimitMemory(info.LimitInBytes);
         }
 
+        public ulong CurrentMemoryLimit()
+        {
+            throw new NotImplementedException();
+        }
+
         private void MemoryLimitReached(object sender, EventArgs e)
         {
             var handler = outOfMemoryHandler;


### PR DESCRIPTION
Hi @brannon 

We're working on adding the ability to constrain memory (https://www.pivotaltracker.com/story/show/92180278) and need the ability to get the current memory limit from the job object. 

We left the ContainerStub implementation throwing a `NotImplementedException` since we weren't sure what that class is for and weren't sure if it was relevant for us.

Ben & Dave